### PR TITLE
fixing print of unicode

### DIFF
--- a/src/gitissuebot/approve.py
+++ b/src/gitissuebot/approve.py
@@ -210,7 +210,7 @@ def check_issues(config, file=None, dryrun=False):
 	for issue in issues:
 		internal = convert_to_internal(issue)
 
-		print("Processing \"%s\" by %s (created %s, last updated %s)" % (internal["title"], internal["author"], internal["created_str"], internal["updated_str"]))
+		print(u"Processing \"%s\" by %s (created %s, last updated %s)" % (internal["title"], internal["author"], internal["created_str"], internal["updated_str"]))
 
 		valid = validator(issue, headers, config)
 


### PR DESCRIPTION
``` sh
+ gitissuebot-approve -c /var/run/GitIssueBot/mail.yaml
Found 9 issues to process...
Traceback (most recent call last):
  File "/usr/local/bin/gitissuebot-approve", line 9, in <module>
    load_entry_point('GitIssueBot==0.1.0-2-g3e2e97c', 'console_scripts', 'gitissuebot-approve')()
  File "/usr/local/lib/python2.7/dist-packages/GitIssueBot-0.1.0_2_g3e2e97c-py2.7.egg/gitissuebot/approve.py", line 422, in main
    check_issues(config, file=args.config, dryrun=config["dryrun"])
  File "/usr/local/lib/python2.7/dist-packages/GitIssueBot-0.1.0_2_g3e2e97c-py2.7.egg/gitissuebot/approve.py", line 213, in check_issues
    print("Processing \"%s\" by %s (created %s, last updated %s)" % (internal["title"], internal["author"], internal["created_str"], internal["updated_str"]))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 45: ordinal not in range(128)
```
